### PR TITLE
Tech: refactorise les barres de navigation principale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'rails', '~> 7.0.5' # allows update to security fixes at any time
 
 gem 'aasm'
 gem 'acsv'
-gem 'active_link_to' # Automatically set a class on active links
 gem 'active_model_serializers'
 gem 'activestorage-openstack'
 gem 'active_storage_validations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,9 +49,6 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_link_to (1.0.5)
-      actionpack
-      addressable
     active_model_serializers (0.10.13)
       actionpack (>= 4.1, < 7.1)
       activemodel (>= 4.1, < 7.1)
@@ -807,7 +804,6 @@ PLATFORMS
 DEPENDENCIES
   aasm
   acsv
-  active_link_to
   active_model_serializers
   active_storage_validations
   activestorage-openstack

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -7,3 +7,10 @@ span.notifications {
   border-radius: 4px;
   background-color: $orange;
 }
+
+.fr-header__tools {
+  .notifications {
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+}

--- a/app/components/instructeur_expert_main_navigation_component.rb
+++ b/app/components/instructeur_expert_main_navigation_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class InstructeurExpertMainNavigationComponent < ApplicationComponent
+  def instructeur?
+    helpers.instructeur_signed_in?
+  end
+
+  def expert?
+    helpers.expert_signed_in?
+  end
+end

--- a/app/components/instructeur_expert_main_navigation_component/instructeur_expert_main_navigation_component.html.haml
+++ b/app/components/instructeur_expert_main_navigation_component/instructeur_expert_main_navigation_component.html.haml
@@ -1,0 +1,13 @@
+.fr-container
+  %nav#header-navigation.fr-nav{ role: :navigation, "aria-label" => t('main_menu', scope: [:layouts, :header]) }
+    %ul.fr-nav__list
+      - if instructeur?
+        %li.fr-nav__item
+          = link_to t('utils.procedure'), instructeur_procedures_path, class: 'fr-nav__link', aria: { current: ['dossiers','procedures'].include?(controller_name) ? 'page' : nil }
+
+      - if expert?
+        %li.fr-nav__item
+          = link_to expert_all_avis_path, class: 'fr-nav__link', aria: { current: helpers.controller_name == 'avis' ? 'page' : nil } do
+            = Avis.model_name.plural.capitalize
+            - if helpers.current_expert.avis_summary[:unanswered] > 0
+              %span.badge.warning= helpers.current_expert.avis_summary[:unanswered]

--- a/app/components/instructeur_expert_main_navigation_component/instructeur_expert_main_navigation_component.html.haml
+++ b/app/components/instructeur_expert_main_navigation_component/instructeur_expert_main_navigation_component.html.haml
@@ -11,3 +11,5 @@
             = Avis.model_name.plural.capitalize
             - if helpers.current_expert.avis_summary[:unanswered] > 0
               %span.badge.warning= helpers.current_expert.avis_summary[:unanswered]
+
+      = render NavBarAnnouncesComponent.new

--- a/app/components/nav_bar_announces_component.rb
+++ b/app/components/nav_bar_announces_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class NavBarAnnouncesComponent < ApplicationComponent
+  def render?
+    @most_recent_released_on = load_most_recent_released_on
+    return false if @most_recent_released_on.nil?
+
+    # also see app/controllers/release_notes_controller.rb#ensure_access_allowed!
+    return true if helpers.instructeur_signed_in?
+    return true if helpers.administrateur_signed_in?
+    return true if helpers.expert_signed_in?
+
+    false
+  end
+
+  def something_new?
+    return true if current_user.announces_seen_at.nil?
+
+    @most_recent_released_on.after? current_user.announces_seen_at
+  end
+
+  def load_most_recent_released_on
+    categories = helpers.infer_default_announce_categories
+
+    ReleaseNote.most_recent_announce_date_for_categories(categories)
+  end
+end

--- a/app/components/nav_bar_announces_component/nav_bar_announces_component.en.yml
+++ b/app/components/nav_bar_announces_component/nav_bar_announces_component.en.yml
@@ -1,0 +1,4 @@
+---
+en:
+  news: News
+  something_new: New informations about the website may be of interest to you.

--- a/app/components/nav_bar_announces_component/nav_bar_announces_component.fr.yml
+++ b/app/components/nav_bar_announces_component/nav_bar_announces_component.fr.yml
@@ -1,0 +1,4 @@
+---
+fr:
+  news: Nouveautés
+  something_new: De nouvelles informations à propos du site pourraient vous intéresser.

--- a/app/components/nav_bar_announces_component/nav_bar_announces_component.html.haml
+++ b/app/components/nav_bar_announces_component/nav_bar_announces_component.html.haml
@@ -1,0 +1,4 @@
+%li.fr-nav__item
+  = link_to t('.news'), release_notes_path, class: "fr-nav__link",'aria-current': current_page?(release_notes_path) ? 'page' : nil
+  - if something_new?
+    %span.notifications{ 'aria-label': t('.something_new') }

--- a/app/controllers/release_notes_controller.rb
+++ b/app/controllers/release_notes_controller.rb
@@ -1,8 +1,20 @@
 class ReleaseNotesController < ApplicationController
   before_action :ensure_access_allowed!
+  after_action :touch_default_categories_seen_at
+
+  def nav_bar_profile
+    # detect context from referer
+    params = Rails.application.routes.recognize_path(request.referer)
+
+    controller_class = "#{params[:controller].camelize}Controller".safe_constantize
+    return if controller_class.nil?
+
+    controller_instance = controller_class.new
+    controller_instance.try(:nav_bar_profile)
+  end
 
   def index
-    @categories = params[:categories].presence || infer_default_categories
+    @categories = params[:categories].presence || helpers.infer_default_announce_categories
 
     # Paginate per groups (per date), then show all announces for theses groups
     @paginated_groups = ReleaseNote.published
@@ -22,16 +34,13 @@ class ReleaseNotesController < ApplicationController
 
   private
 
-  def infer_default_categories
-    if administrateur_signed_in?
-      ['administrateur', 'usager', current_administrateur.api_tokens.exists? ? 'api' : nil]
-    elsif instructeur_signed_in?
-      ['instructeur', 'expert']
-    elsif expert_signed_in?
-      ['expert']
-    else
-      ['usager']
-    end
+  def touch_default_categories_seen_at
+    return if params[:categories].present? || params[:page].present?
+    return if current_user.blank?
+
+    return if current_user.announces_seen_at&.after?(@announces.max_by(&:released_on).released_on)
+
+    current_user.touch(:announces_seen_at)
   end
 
   def ensure_access_allowed!

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -76,6 +76,10 @@ module Users
       retrieve_procedure
     end
 
+    def nav_bar_profile
+      current_user ? :user : :guest
+    end
+
     private
 
     def extra_query_params

--- a/app/helpers/release_notes_helper.rb
+++ b/app/helpers/release_notes_helper.rb
@@ -15,4 +15,16 @@ module ReleaseNotesHelper
 
     content_tag(:span, category.humanize, class: "fr-badge #{color_class}")
   end
+
+  def infer_default_announce_categories
+    if administrateur_signed_in?
+      ReleaseNote.default_categories_for_role(:administrateur, current_administrateur)
+    elsif instructeur_signed_in?
+      ReleaseNote.default_categories_for_role(:instructeur)
+    elsif expert_signed_in?
+      ReleaseNote.default_categories_for_role(:expert)
+    else
+      ReleaseNote.default_categories_for_role(:usager)
+    end
+  end
 end

--- a/app/models/release_note.rb
+++ b/app/models/release_note.rb
@@ -14,4 +14,21 @@ class ReleaseNote < ApplicationRecord
 
   scope :published, -> { where(published: true) }
   scope :for_categories, -> (categories) { where("categories && ARRAY[?]::varchar[]", categories) }
+
+  def self.default_categories_for_role(role, instance = nil)
+    case role
+    when :administrateur
+      ['administrateur', 'usager', instance.api_tokens.exists? ? 'api' : nil]
+    when :instructeur
+      ['instructeur']
+    when :expert
+      ['expert']
+    else
+      ['usager']
+    end
+  end
+
+  def self.most_recent_announce_date_for_categories(categories)
+    published.for_categories(categories).maximum(:released_on)
+  end
 end

--- a/app/views/administrateurs/_main_navigation.html.haml
+++ b/app/views/administrateurs/_main_navigation.html.haml
@@ -4,3 +4,6 @@
       %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'true' : nil
       - if Rails.application.config.ds_zonage_enabled
         %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: current_administrateur.zones), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil
+
+      = render NavBarAnnouncesComponent.new
+

--- a/app/views/administrateurs/_main_navigation.html.haml
+++ b/app/views/administrateurs/_main_navigation.html.haml
@@ -1,6 +1,6 @@
 .fr-container
   %nav#header-navigation.fr-nav{ role: 'navigation', 'aria-label': 'Menu principal administrateur' }
     %ul.fr-nav__list
-      %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'procedures', action: :index) ? 'true' : nil
+      %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'true' : nil
       - if Rails.application.config.ds_zonage_enabled
         %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: current_administrateur.zones), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil

--- a/app/views/administrateurs/procedures/index.html.haml
+++ b/app/views/administrateurs/procedures/index.html.haml
@@ -1,4 +1,5 @@
-= render 'main_menu'
+- content_for(:navigation_principale) do
+  = render 'administrateurs/main_navigation'
 
 .sub-header
   .procedure-admin-listing-container

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -3,6 +3,7 @@
 - dossier = controller.try(:dossier_for_help)
 - procedure = controller.try(:procedure_for_help)
 - is_instructeur_context = nav_bar_profile == :instructeur && instructeur_signed_in?
+- is_administrateur_context = nav_bar_profile == :administrateur && administrateur_signed_in?
 - is_expert_context = nav_bar_profile == :expert && expert_signed_in?
 - is_user_context = nav_bar_profile == :user
 - is_search_enabled = [params[:controller] == 'recherche', is_instructeur_context, is_expert_context, is_user_context && current_user.dossiers.count].any?
@@ -68,36 +69,21 @@
           - if is_expert_context
             = render partial: 'layouts/search_dossiers_form'
 
-  - has_header = [is_instructeur_context, is_expert_context, is_user_context]
+  - if is_administrateur_context
+    = render 'administrateurs/main_navigation'
+  - elsif is_instructeur_context || is_expert_context
+    = render InstructeurExpertMainNavigationComponent.new
+  - elsif is_user_context
+    = render 'users/main_navigation'
+  - elsif content_for?(:navigation_principale)
+    .fr-container
+      = yield(:navigation_principale)
+
   #burger-menu.fr-header__menu.fr-modal
     .fr-container
       %button#burger_button.fr-btn--close.fr-btn{ "aria-controls" => "burger-menu", :title => t('close_modal', scope: [:layouts, :header]) }= t('close_modal', scope: [:layouts, :header])
       .fr-header__menu-links
-      %nav#navigation-478.fr-nav{ "aria-label" => t('main_menu', scope: [:layouts, :header]) , :role => "navigation" }
-        %ul.fr-nav__list
-          -# Questionner UX pour un back JS
-          - if params[:controller] == 'users/commencer'
-            %li.fr-nav__item
-              = link_to t('back', scope: [:layouts, :header]), url_for(:back), title: t('back_title', scope: [:layouts, :header]), class: 'fr-nav__link'
 
-          - if is_instructeur_context
-            - if current_instructeur.procedures.any?
-              - current_url = request.path_info
-              %li.fr-nav__item
-                = active_link_to t('utils.procedure'), instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'fr-nav__link', aria: { current: current_url == instructeur_procedures_path ? 'page' : true }
-            - if current_instructeur.user.expert && current_expert.avis_summary[:total] > 0
-              = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
-
-          - if is_expert_context
-            - if current_expert.user.instructeur && current_instructeur.procedures.any?
-              %li.fr-nav__item= active_link_to t('utils.procedure'), instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'fr-nav__link', aria: { current: true }
-            - if current_expert.avis_summary[:total] > 0
-              = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
-
-          - if is_user_context
-            %li.fr-nav__item= active_link_to t('.files'), dossiers_path, active: :inclusive, class: 'fr-nav__link', aria: { current: true }
-            - if current_user.expert && current_expert.avis_summary[:total] > 0
-              = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
 
   - if content_for?(:navigation_principale)
     .fr-container

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -1,5 +1,8 @@
+- content_for(:navigation_principale) do
+  = render 'administrateurs/main_navigation'
+
 - content_for :content do
-  = render 'main_menu'
+
   .fr-container
     %h1.fr-my-4w Toutes les démarches
 

--- a/app/views/layouts/header/_avis_tab.html.haml
+++ b/app/views/layouts/header/_avis_tab.html.haml
@@ -1,5 +1,0 @@
-%li.fr-nav__item
-  = active_link_to expert_all_avis_path, active: controller_name == 'avis', class: 'fr-nav__link' do
-    Avis
-    - if current_expert.avis_summary[:unanswered] > 0
-      %span.badge.warning= current_expert.avis_summary[:unanswered]

--- a/app/views/users/_main_navigation.html.haml
+++ b/app/views/users/_main_navigation.html.haml
@@ -1,0 +1,9 @@
+.fr-container
+  %nav#header-navigation.fr-nav{ role: :navigation, "aria-label" => t('main_menu', scope: [:layouts, :header]) }
+    %ul.fr-nav__list
+      - if params[:controller] == 'users/commencer'
+        %li.fr-nav__item
+          = link_to t('back', scope: [:layouts, :header]), url_for(:back), title: t('back_title', scope: [:layouts, :header]), class: 'fr-nav__link'
+
+      %li.fr-nav__item
+        = link_to t('files', scope: [:layouts, :header]), dossiers_path, active: :inclusive, class: 'fr-nav__link', aria: { current: 'page' }

--- a/spec/components/instructeur_expert_main_navigation_component_spec.rb
+++ b/spec/components/instructeur_expert_main_navigation_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InstructeurExpertMainNavigationComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end

--- a/spec/components/nav_bar_announces_component_spec.rb
+++ b/spec/components/nav_bar_announces_component_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NavBarAnnouncesComponent, type: :component do
+  let(:user) { build(:user) }
+  let!(:admin_release_note) { create(:release_note, released_on: Date.yesterday, categories: ["administrateur"]) }
+  let!(:instructeur_release_note) { create(:release_note, released_on: Date.yesterday, categories: ["instructeur"]) }
+  let(:not_published_release_note) { create(:release_note, published: false, released_on: Date.tomorrow) }
+
+  let(:as_administrateur) { false }
+  let(:as_instructeur) { false }
+
+  before do
+    if as_administrateur
+      user.build_administrateur
+    end
+
+    if as_instructeur
+      user.build_instructeur
+    end
+
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  subject { render_inline(described_class.new) }
+
+  context 'when signed as simple user' do
+    it 'does not render the announcements link if not signed in' do
+      expect(subject.to_html).to be_empty
+    end
+  end
+
+  context 'when no signed in' do
+    let(:current_user) { nil }
+
+    it 'does not render the announcements link if not signed in' do
+      expect(subject.to_html).to be_empty
+    end
+  end
+
+  context 'when instructeur signed in' do
+    let(:as_instructeur) { true }
+
+    it 'renders the announcements link' do
+      expect(subject).to have_link("Nouveautés")
+    end
+
+    context 'when there are new announcements' do
+      before do
+        user.announces_seen_at = 5.days.ago
+      end
+
+      it 'does not render the notification badge' do
+        expect(subject).to have_link("Nouveautés")
+        expect(subject).to have_css(".notifications")
+      end
+    end
+
+    context 'when there are no new announcements' do
+      before do
+        user.announces_seen_at = 1.minute.ago
+      end
+
+      it 'does not render the notification badge' do
+        expect(subject).to have_link("Nouveautés")
+        expect(subject).not_to have_css(".notifications")
+      end
+    end
+
+    context 'when there are no announcement at all' do
+      let(:instructeur_release_note) { nil }
+
+      it 'does not render anything' do
+        expect(subject.to_html).to be_empty
+      end
+    end
+  end
+
+  context 'when administrateur signed in' do
+    let(:as_administrateur) { true }
+
+    it 'renders the announcements link' do
+      expect(subject).to have_link("Nouveautés")
+    end
+  end
+end

--- a/spec/components/previews/instructeur_expert_main_navigation_component_preview.rb
+++ b/spec/components/previews/instructeur_expert_main_navigation_component_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class InstructeurExpertMainNavigationComponentPreview < ViewComponent::Preview
+  def default
+    render(InstructeurExpertMainNavigationComponent.new)
+  end
+end

--- a/spec/controllers/release_notes_controller_spec.rb
+++ b/spec/controllers/release_notes_controller_spec.rb
@@ -47,5 +47,31 @@ RSpec.describe ReleaseNotesController, type: :controller do
         it { is_expected.to be_redirection }
       end
     end
+
+    describe 'touch user announces_seen_at' do
+      let(:user) { create(:user, administrateur: build(:administrateur)) }
+
+      context 'when default categories' do
+        it 'touch announces_seen_at' do
+          expect { subject }.to change { user.reload.announces_seen_at }
+        end
+
+        context 'when current announces_seen_at is more recent than last announce' do
+          before { user.update(announces_seen_at: 1.second.ago) }
+
+          it 'does not touch announces_seen_at' do
+            expect { subject }.not_to change { user.reload.announces_seen_at }
+          end
+        end
+      end
+
+      context 'when specific categories' do
+        subject { get :index, params: { categories: ['administrateur', 'instructeur'] } }
+
+        it 'does not touch announces_seen_at' do
+          expect { subject }.not_to change { user.reload.announces_seen_at }
+        end
+      end
+    end
   end
 end

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -5,6 +5,8 @@ describe 'layouts/_header', type: :view do
     allow(view).to receive(:multiple_devise_profile_connect?).and_return(false)
     allow(view).to receive(:instructeur_signed_in?).and_return((profile == :instructeur))
     allow(view).to receive(:current_instructeur).and_return(current_instructeur)
+    allow(view).to receive(:administrateur_signed_in?).and_return(false)
+    allow(view).to receive(:expert_signed_in?).and_return(false)
     allow(view).to receive(:localization_enabled?).and_return(false)
 
     if user
@@ -57,12 +59,17 @@ describe 'layouts/_header', type: :view do
     let(:user) { instructeur.user }
     let(:profile) { :instructeur }
     let(:current_instructeur) { instructeur }
+    let!(:release_note) { create(:release_note, categories: ['instructeur']) }
 
     it { is_expected.to have_css(".fr-header__logo") }
     it { is_expected.to have_selector(:button, user.email, class: "account-btn") }
 
     it 'displays the Help dropdown menu' do
       expect(subject).to have_css(".help-dropdown")
+    end
+
+    it 'displays the Help dropdown menu' do
+      expect(subject).to have_link("Nouveautés")
     end
   end
 end

--- a/spec/views/layouts/procedure_context.html.haml_spec.rb
+++ b/spec/views/layouts/procedure_context.html.haml_spec.rb
@@ -5,6 +5,7 @@ describe 'layouts/procedure_context', type: :view do
   before do
     allow(view).to receive(:instructeur_signed_in?).and_return(false)
     allow(view).to receive(:administrateur_signed_in?).and_return(false)
+    allow(view).to receive(:expert_signed_in?).and_return(false)
     allow(view).to receive(:localization_enabled?).and_return(false)
   end
 


### PR DESCRIPTION
## A merger après #9638

2è partie de la PR des annonces qui : 

- intègre le lien vers la nouvelle page depuis la barre de navigation principale contextuelles par profile
- réorganise toute la logique de génération de la navigation principale dans le header
