### PR TITLE
ETQ instructeur, pas d'erreur JS si on copie rapidement 2x le même élément

### DIFF
--- a/app/javascript/controllers/clipboard2_controller.ts
+++ b/app/javascript/controllers/clipboard2_controller.ts
@@ -85,6 +85,9 @@ export class Clipboard2Controller extends Controller {
   }
 
   private insertSpan(wrapper: HTMLElement, span: HTMLElement): void {
+    // Remove span from DOM if it's already attached from a previous insertion
+    span.remove();
+
     const placeholder = wrapper.querySelector<HTMLElement>(
       '[data-copy-message-placeholder]'
     );

--- a/app/javascript/controllers/clipboard2_controller.ts
+++ b/app/javascript/controllers/clipboard2_controller.ts
@@ -82,6 +82,10 @@ export class Clipboard2Controller extends Controller {
     this.#timer = setTimeout(() => {
       this.#copiedSpan.remove();
     }, SUCCESS_MESSAGE_TIMEOUT);
+
+    wrapper.addEventListener('mouseleave', () => {
+      this.#copiedSpan.remove();
+    });
   }
 
   private insertSpan(wrapper: HTMLElement, span: HTMLElement): void {


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/6880493711/

ça arrivait si on recopie une 2e fois juste après une première copie, alors que "Copié" est encore affiché. D'ailleurs on évite aussi d'avoir 2x simultanément "copié" puis "cliquer pour copier" car la 2nde copie copiait aussi le texte "copié" (dire ça très vite à voix haute)