### PR TITLE
Tech: streame les exports xlsx pour borner la consommation RAM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,7 @@ gem 'view_component'
 gem 'vite_rails'
 gem 'warden'
 gem 'webrick', require: false
+gem 'xlsxtream'
 gem 'yabeda-prometheus'
 gem 'yabeda-sidekiq'
 gem 'zipline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -971,6 +971,8 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xlsxtream (3.1.0)
+      zip_kit (>= 6.2, < 7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yabeda (0.14.0)
@@ -1156,6 +1158,7 @@ DEPENDENCIES
   web-console
   webmock
   webrick
+  xlsxtream
   yabeda-prometheus
   yabeda-sidekiq
   zipline

--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -7,7 +7,7 @@ class ActiveStorage::DownloadableFile
     pj_service = PiecesJustificativesService.new(user_profile:, export_template:)
 
     files = []
-    DossierPreloader.new(dossiers).in_batches_with_block do |loaded_dossiers|
+    DossierPreloader.new(dossiers).in_batches(includes: DossierPreloader::PJ_EXPORT_INCLUDES) do |loaded_dossiers|
       files += pj_service.generate_dossiers_export(loaded_dossiers) + pj_service.liste_documents(loaded_dossiers)
     end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -483,18 +483,15 @@ class Dossier < ApplicationRecord
   validates :mandataire_last_name, presence: true, if: :for_tiers?
   validates :for_tiers, inclusion: { in: [true, false] }, if: -> { revision&.procedure&.for_individual? }
 
+  # csv/ods construisent tout le classeur en mémoire d'un coup (spreadsheet_architect) :
+  # on matérialise donc l'ensemble des dossiers triés et préchargés. On passe par
+  # `in_batches` seulement pour précharger les champs par tranches adaptatives
+  # (plutôt qu'en une requête champs géante), et on rassemble les batches.
   def self.downloadable_sorted_batch
-    DossierPreloader.new(includes(
-      :user,
-      :individual,
-      :followers_instructeurs,
-      :traitement,
-      :groupe_instructeur,
-      :etablissement,
-      :pending_corrections,
-      procedure: [:groupe_instructeurs],
-      avis: [:claimant, :expert]
-    ).ordered_for_export).in_batches
+    [].tap do |dossiers|
+      DossierPreloader.new(ordered_for_export)
+        .in_batches(includes: DossierPreloader::SHEET_EXPORT_INCLUDES) { |batch| dossiers.concat(batch) }
+    end
   end
 
   def user_deleted?

--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -4,24 +4,42 @@ class DossierPreloader
   DEFAULT_BATCH_SIZE = 2000
   MAX_CHAMPS_PER_BATCH = 140_000
 
+  # Associations préchargées pour l'export tableur (feuilles Dossiers/Etablissements/Avis).
+  SHEET_EXPORT_INCLUDES = [
+    :user, :individual, :followers_instructeurs, :traitement, :groupe_instructeur,
+    :etablissement, :pending_corrections,
+    { procedure: [:groupe_instructeurs], avis: [:claimant, :expert] },
+  ].freeze
+
+  # Associations préchargées pour l'export PDF/zip (PiecesJustificativesService).
+  PJ_EXPORT_INCLUDES = [
+    :individual, :traitement, :etablissement, :pending_corrections,
+    { user: :france_connect_informations, avis: :expert, commentaires: [:instructeur, :expert] },
+  ].freeze
+
   def initialize(dossiers, includes_for_champ: [], includes_for_etablissement: [])
     @dossiers = dossiers
     @includes_for_etablissement = includes_for_etablissement
     @includes_for_champ = includes_for_champ
   end
 
-  def in_batches
-    dossiers = @dossiers.to_a
-    batch_size = adaptive_batch_size(dossiers)
-    dossiers.each_slice(batch_size) { load_dossiers(it) }
-    dossiers
-  end
+  # Streame les dossiers dans l'ordre de la relation, par batches adaptatifs.
+  # Chaque batch est rechargé avec `includes`, préchargé, yieldé puis relâché :
+  # seuls les ids de l'ensemble + un batch de dossiers vivent à la fois.
+  # L'ordre est choisi par l'appelant sur la relation (ex: `ordered_for_export`).
+  def in_batches(includes:)
+    ids = @dossiers.ids
+    return if ids.empty?
 
-  def in_batches_with_block(&block)
-    @dossiers.in_batches(of: adaptive_batch_size(@dossiers)) do |batch|
-      data = Dossier.where(id: batch.ids).includes(:individual, :traitement, :etablissement, :pending_corrections, user: :france_connect_informations, avis: :expert, commentaires: [:instructeur, :expert])
+    # On dimensionne les batches d'après la révision *active*
+    sample_revision = @dossiers.first.procedure.active_revision
 
-      dossiers = data.to_a
+    ids.each_slice(adaptive_batch_size(ids.size, sample_revision)) do |batch_ids|
+      dossiers_by_id = Dossier.where(id: batch_ids).includes(includes).index_by(&:id)
+
+      # Ré-applique l'ordre original
+      dossiers = batch_ids.filter_map { dossiers_by_id[it] }
+
       load_dossiers(dossiers)
       yield(dossiers)
     end
@@ -133,11 +151,15 @@ class DossierPreloader
     dossier.send(:reset_champs_cache)
   end
 
-  def adaptive_batch_size(dossiers)
-    return DEFAULT_BATCH_SIZE if dossiers.count < DEFAULT_BATCH_SIZE
+  # - `count` : nombre de dossiers à batcher
+  # - `sample_revision` : révision de référence (la révision active de la démarche)
+  # pour estimer le nombre de champs par dossier,
+  # afin qu'un batch ne charge jamais plus de MAX_CHAMPS_PER_BATCH champs d'un coup.
+  def adaptive_batch_size(count, sample_revision)
+    return DEFAULT_BATCH_SIZE if count < DEFAULT_BATCH_SIZE
 
     # Prend un ordre de grandeur de la taille de la démarche
-    champs_per_dossier = dossiers.last.revision.types_de_champ.count + 1
+    champs_per_dossier = sample_revision&.types_de_champ&.count.to_i + 1
 
     # Reste sur un multiple de 100
     ideal_batch_size = (MAX_CHAMPS_PER_BATCH / champs_per_dossier).round(-2)

--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -53,6 +53,15 @@ class ProcedureExportService
     create_blob(io, :json)
   end
 
+  # Nettoie un nom d'onglet pour Excel : translittération en ASCII (pour que
+  # truncate respecte la limite de 30 octets) puis suppression des caractères
+  # interdits par Excel (/\*?[]:) — caxlsx levait sur ces caractères, xlsxtream non.
+  def self.sanitize_sheet_name(name)
+    I18n.transliterate(name, locale: :en)
+      .delete('/\*?[]:')
+      .truncate(30, omission: '')
+  end
+
   private
 
   def create_blob(io, format)
@@ -138,12 +147,7 @@ class ProcedureExportService
       table
     end.merge(DEFAULT_STYLES)
 
-    # transliterate: convert to ASCII characters
-    # to ensure truncate respects 30 bytes
-    # /\*?[] are invalid Excel worksheet characters
-    options[:sheet_name] = I18n.transliterate(options[:sheet_name], locale: :en)
-      .delete('/\*?[]')
-      .truncate(30, omission: '')
+    options[:sheet_name] = self.class.sanitize_sheet_name(options[:sheet_name])
 
     options
   end

--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -17,14 +17,11 @@ class ProcedureExportService
   end
 
   def to_xlsx
-    @dossiers = @dossiers.downloadable_sorted_batch
-    tables = [:dossiers, :etablissements, :avis] + champs_repetables_options(format: :xlsx)
-
-    # We recursively build multi page spreadsheet
-    io = tables.reduce(nil) do |package, table|
-      SpreadsheetArchitect.to_axlsx_package(options_for(table, :xlsx), package)
-    end.to_stream
-    create_blob(io, :xlsx)
+    Tempfile.create(['export', '.xlsx'], binmode: true) do |file|
+      XlsxExport.new(procedure:, dossiers:, export_template: @export_template).write_to(file)
+      file.rewind
+      create_blob(file, :xlsx)
+    end
   end
 
   def to_ods

--- a/app/services/procedure_export_service/xlsx_export.rb
+++ b/app/services/procedure_export_service/xlsx_export.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+# Streams a procedure's dossiers into an xlsx file with bounded memory: the
+# Dossiers sheet is written row by row while the secondary sheets
+# (Etablissements, Avis, Repetitions) are buffered as primitive values and
+# flushed once Dossiers is closed (xlsxtream cannot interleave sheets).
+#
+# Kept separate from ProcedureExportService so the multi-format service stays a
+# thin dispatcher; the same streaming shape can later back a CSV export.
+class ProcedureExportService::XlsxExport
+  def initialize(procedure:, dossiers:, export_template:)
+    @procedure = procedure
+    @dossiers = dossiers
+    @export_template = export_template
+  end
+
+  # Résout une cellule `[libellé, valeur, type]` (le type n'est présent que via
+  # export_template). Reproduit le typage de SpreadsheetArchitect : un booléen
+  # ne devient une cellule native (t="b") que si la colonne est explicitement
+  # typée `:boolean` ; sinon il est stringifié — comme l'export caxlsx précédent,
+  # où `get_type` ne typait jamais les booléens auto-détectés.
+  def self.cell_value(instance, value, type)
+    value = instance.send(value) if value.is_a?(Symbol)
+
+    if (value == true || value == false) && type != :boolean
+      value.to_s
+    else
+      value
+    end
+  end
+
+  def write_to(io)
+    buffers = SecondarySheetBuffers.new(procedure: @procedure)
+
+    ProcedureExportService::XlsxStreamer.new(io).open do |writer|
+      stream_dossiers_sheet(writer, buffers)
+      flush_etablissements_sheet(writer, buffers)
+      flush_avis_sheet(writer, buffers)
+      flush_repetition_sheets(writer, buffers)
+    end
+  end
+
+  private
+
+  def stream_dossiers_sheet(writer, buffers)
+    writer.write_sheet('Dossiers', headers: dossiers_headers) do |sheet|
+      DossierPreloader.new(@dossiers.ordered_for_export)
+        .in_batches(includes: DossierPreloader::SHEET_EXPORT_INCLUDES) do |batch|
+        batch.each do |dossier|
+          row = dossier.spreadsheet_columns_xlsx(types_de_champ:, export_template: @export_template)
+          sheet.add_row(row.map { |(_libelle, value, type)| self.class.cell_value(dossier, value, type) })
+
+          buffers.collect_for_dossier(dossier, @export_template)
+        end
+      end
+    end
+  end
+
+  def flush_etablissements_sheet(writer, buffers)
+    writer.write_sheet('Etablissements', headers: buffers.etablissements_headers) do |sheet|
+      buffers.etablissements_rows.each { |values| sheet.add_row(values) }
+    end
+  end
+
+  def flush_avis_sheet(writer, buffers)
+    writer.write_sheet('Avis', headers: buffers.avis_headers) do |sheet|
+      buffers.avis_rows.each { |values| sheet.add_row(values) }
+    end
+  end
+
+  def flush_repetition_sheets(writer, buffers)
+    buffers.repetition_sheets.each do |(libelle, headers, rows)|
+      writer.write_sheet(libelle, headers:) do |sheet|
+        rows.each { |values| sheet.add_row(values) }
+      end
+    end
+  end
+
+  def dossiers_headers
+    return @dossiers_headers if defined?(@dossiers_headers)
+
+    # Précalcul depuis une instance "sentinelle" pour garantir la cohérence
+    # libellé ↔ valeur. Si pas de dossier, on ouvre quand même une sheet vide.
+    sample = @dossiers.first
+    @dossiers_headers = if sample.present?
+      DossierPreloader.load_one(sample)
+        .spreadsheet_columns_xlsx(types_de_champ:, export_template: @export_template)
+        .map(&:first)
+    else
+      []
+    end
+  end
+
+  def types_de_champ
+    @types_de_champ ||= @procedure.types_de_champ_for_procedure_export.to_a
+  end
+
+  # Accumulates rows for the Etablissements, Avis and Repetition sheets while we
+  # stream the main Dossiers sheet.
+  #
+  # Values from `spreadsheet_columns` may be raw values or Symbols (method names
+  # to call on the source instance, mimicking SpreadsheetArchitect behavior).
+  # We resolve them at collection time so the buffer only holds primitive values.
+  class SecondarySheetBuffers
+    ETABLISSEMENT_HEADERS = Etablissement.new.spreadsheet_columns.map(&:first).freeze
+    AVIS_HEADERS = Avis.new.spreadsheet_columns.map(&:first).freeze
+
+    def initialize(procedure:)
+      @procedure = procedure
+      @etablissements_buffer = []
+      @avis_buffer = []
+      @repetition_buffers = {} # stable_id => { libelle:, headers:, rows: [] }
+    end
+
+    def collect_for_dossier(dossier, export_template)
+      collect_etablissements(dossier)
+      collect_avis(dossier)
+      collect_repetitions(dossier, export_template)
+    end
+
+    def etablissements_headers = ETABLISSEMENT_HEADERS
+    def etablissements_rows = @etablissements_buffer
+    def avis_headers = AVIS_HEADERS
+    def avis_rows = @avis_buffer
+
+    def repetition_sheets
+      @repetition_buffers.values.filter_map do |entry|
+        next if entry[:rows].empty?
+        [entry[:libelle], entry[:headers], entry[:rows]]
+      end
+    end
+
+    private
+
+    def collect_etablissements(dossier)
+      dossier.filled_champs.filter(&:siret?).filter_map(&:etablissement).each do |etablissement|
+        @etablissements_buffer << resolve_values(etablissement, etablissement.spreadsheet_columns)
+      end
+
+      if dossier.etablissement
+        @etablissements_buffer << resolve_values(dossier.etablissement, dossier.etablissement.spreadsheet_columns)
+      end
+    end
+
+    def collect_avis(dossier)
+      dossier.avis.each do |avis|
+        @avis_buffer << resolve_values(avis, avis.spreadsheet_columns)
+      end
+    end
+
+    def collect_repetitions(dossier, export_template)
+      repetition_tdcs.each do |tdc|
+        rows = dossier.repetition_rows_for_export(tdc)
+        next if rows.empty?
+
+        children_tdcs = repetition_children_tdcs[tdc.stable_id]
+        entry = @repetition_buffers[tdc.stable_id] ||= {
+          libelle: tdc.libelle_for_export,
+          headers: nil,
+          rows: [],
+        }
+
+        rows.each do |row|
+          columns = row.spreadsheet_columns(children_tdcs, export_template:, format: :xlsx)
+          entry[:headers] ||= columns.map(&:first)
+          entry[:rows] << resolve_values(row, columns)
+        end
+      end
+    end
+
+    def repetition_tdcs
+      @repetition_tdcs ||= @procedure.all_revisions_types_de_champ.repetition.to_a
+    end
+
+    def repetition_children_tdcs
+      @repetition_children_tdcs ||= repetition_tdcs.to_h do |tdc|
+        [tdc.stable_id, @procedure.all_revisions_types_de_champ(parent: tdc).to_a]
+      end
+    end
+
+    def resolve_values(instance, columns)
+      columns.map do |(_libelle, value, type)|
+        ProcedureExportService::XlsxExport.cell_value(instance, value, type)
+      end
+    end
+  end
+end

--- a/app/services/procedure_export_service/xlsx_streamer.rb
+++ b/app/services/procedure_export_service/xlsx_streamer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class ProcedureExportService::XlsxStreamer
+  def initialize(io)
+    @io = io
+  end
+
+  def open
+    Xlsxtream::Workbook.open(@io) do |workbook|
+      @workbook = workbook
+      yield(self)
+    end
+  end
+
+  def write_sheet(name, headers:)
+    sanitized = ProcedureExportService.sanitize_sheet_name(name)
+    @workbook.write_worksheet(sanitized, columns: column_widths(headers)) do |sheet|
+      sheet.add_styled_row(headers, style: Xlsxtream::HEADER_STYLE)
+      # On yielde la feuille xlsxtream brute : xlsxtream coerce lui-même nil → cellule
+      # vide et Symbol → texte (cf. Row#to_xml). Les valeurs sont par ailleurs déjà
+      # résolues et typées en amont par XlsxExport.cell_value (parité SpreadsheetArchitect,
+      # ex. booléen non typé → texte). Pas d'échappement de formule : une cellule chaîne
+      # xlsx n'est jamais évaluée (seul un <f> l'est).
+      yield(sheet)
+    end
+  end
+
+  private
+
+  # Le streaming interdit l'autofit : on dimensionne d'après le libellé d'en-tête,
+  # avec un plancher assez large pour que les colonnes de valeurs (texte, dates
+  # « yyyy-mm-dd h:mm AM/PM », emails…) restent lisibles, et un plafond pour
+  # éviter qu'un libellé à rallonge n'étale la colonne.
+  def column_widths(headers)
+    headers.map { { width_chars: it.to_s.length.clamp(22, 60) } }
+  end
+end

--- a/lib/core_ext/xlsxtream.rb
+++ b/lib/core_ext/xlsxtream.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# Portable patches for xlsxtream 3.1.0 (streaming xlsx exports, see
+# ProcedureExportService::XlsxStreamer). xlsxtream hardcodes its stylesheet and
+# exposes no per-cell styling API, so we:
+#   - add a black-fill / white-bold header style, applied to each header *cell*
+#     (Numbers ignores row-level styles), via Worksheet#add_styled_row
+#   - replace xlsxtream's escaped custom date formats with the ones caxlsx used
+#     (built-in short date + "yyyy-mm-dd h:mm AM/PM"), which Numbers reads as
+#     dates and which match the previous (caxlsx) export byte-for-byte
+#
+# All confined here (auto-required by config/initializers/core_ext.rb, like the
+# other gem extensions in lib/core_ext); remove if xlsxtream ever exposes these
+# natively. https://github.com/felixbuenemann/xlsxtream
+if Xlsxtream::VERSION != "3.1.0"
+  raise "xlsxtream #{Xlsxtream::VERSION}: review patches in #{__FILE__} " \
+        "(styles.xml / Row#to_xml internals may have changed)"
+end
+
+module Xlsxtream
+  # cellXfs index of the header style defined in StyledWorkbook#write_styles below.
+  HEADER_STYLE = 3
+
+  module StyledWorkbook
+    private
+
+    # Full override of upstream's hardcoded stylesheet. Differences:
+    #   - dates (cellXf 1) use the built-in short-date format (numFmtId 14)
+    #   - datetimes (cellXf 2) use "yyyy-mm-dd h:mm AM/PM"
+    #   - header (cellXf 3) uses a white bold font on a black fill
+    # The font is hardcoded to upstream's default (we never pass the :font option).
+    def write_styles
+      @writer.add_file "xl/styles.xml"
+      @writer << XML.header
+      @writer << XML.strip(<<-XML)
+        <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <numFmts count="1">
+            <numFmt numFmtId="165" formatCode="yyyy-mm-dd h:mm AM/PM"/>
+          </numFmts>
+          <fonts count="2">
+            <font>
+              <sz val="12"/>
+              <name val="Calibri"/>
+              <family val="2"/>
+            </font>
+            <font>
+              <b/>
+              <sz val="12"/>
+              <color rgb="FFFFFFFF"/>
+              <name val="Calibri"/>
+              <family val="2"/>
+            </font>
+          </fonts>
+          <fills count="3">
+            <fill>
+              <patternFill patternType="none"/>
+            </fill>
+            <fill>
+              <patternFill patternType="gray125"/>
+            </fill>
+            <fill>
+              <patternFill patternType="solid">
+                <fgColor rgb="FF000000"/>
+                <bgColor indexed="64"/>
+              </patternFill>
+            </fill>
+          </fills>
+          <borders count="1">
+            <border/>
+          </borders>
+          <cellStyleXfs count="1">
+            <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+          </cellStyleXfs>
+          <cellXfs count="4">
+            <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+            <xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+            <xf numFmtId="165" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+            <xf numFmtId="0" fontId="1" fillId="2" borderId="0" xfId="0" applyFont="1" applyFill="1"/>
+          </cellXfs>
+          <cellStyles count="1">
+            <cellStyle name="Normal" xfId="0" builtinId="0"/>
+          </cellStyles>
+          <dxfs count="0"/>
+          <tableStyles count="0" defaultTableStyle="TableStyleMedium9" defaultPivotStyle="PivotStyleLight16"/>
+        </styleSheet>
+      XML
+    end
+  end
+  Workbook.prepend(StyledWorkbook)
+
+  # Applies a style to every cell of a row. Numbers ignores row-level styling
+  # (<row s=.. customFormat="1">), so we add an explicit s= on each <c>, like
+  # caxlsx does. We call super (keeping upstream's cell-typing untouched) then
+  # inject s= into each cell that doesn't already carry one.
+  module StyledRow
+    def initialize(row, rownum, options = {})
+      super
+      @row_style = options[:row_style]
+    end
+
+    def to_xml
+      xml = super
+      return xml unless @row_style
+
+      xml.gsub(/<c r="[A-Z]+\d+"(?! s=)/) { |cell| %(#{cell} s="#{@row_style}") }
+    end
+  end
+  Row.prepend(StyledRow)
+
+  # The only entry point to write a row with a row-level style.
+  module StyledWorksheet
+    def add_styled_row(row, style:)
+      @io << Row.new(row, @rownum, @options.merge(row_style: style)).to_xml
+      @rownum += 1
+    end
+  end
+  Worksheet.prepend(StyledWorksheet)
+end

--- a/lib/core_ext/xlsxtream.rb
+++ b/lib/core_ext/xlsxtream.rb
@@ -6,8 +6,9 @@
 #   - add a black-fill / white-bold header style, applied to each header *cell*
 #     (Numbers ignores row-level styles), via Worksheet#add_styled_row
 #   - replace xlsxtream's escaped custom date formats with the ones caxlsx used
-#     (built-in short date + "yyyy-mm-dd h:mm AM/PM"), which Numbers reads as
-#     dates and which match the previous (caxlsx) export byte-for-byte
+#     ("yyyy-mm-dd" + "yyyy-mm-dd h:mm AM/PM"), which spreadsheet readers (Excel,
+#     LibreOffice, Numbers…) read as dates and which match the previous (caxlsx)
+#     export
 #
 # All confined here (auto-required by config/initializers/core_ext.rb, like the
 # other gem extensions in lib/core_ext); remove if xlsxtream ever exposes these
@@ -25,7 +26,8 @@ module Xlsxtream
     private
 
     # Full override of upstream's hardcoded stylesheet. Differences:
-    #   - dates (cellXf 1) use the built-in short-date format (numFmtId 14)
+    #   - dates (cellXf 1) use "yyyy-mm-dd" (caxlsx used this custom code, not the
+    #     locale-dependent built-in numFmtId 14)
     #   - datetimes (cellXf 2) use "yyyy-mm-dd h:mm AM/PM"
     #   - header (cellXf 3) uses a white bold font on a black fill
     # The font is hardcoded to upstream's default (we never pass the :font option).
@@ -34,7 +36,8 @@ module Xlsxtream
       @writer << XML.header
       @writer << XML.strip(<<-XML)
         <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-          <numFmts count="1">
+          <numFmts count="2">
+            <numFmt numFmtId="164" formatCode="yyyy-mm-dd"/>
             <numFmt numFmtId="165" formatCode="yyyy-mm-dd h:mm AM/PM"/>
           </numFmts>
           <fonts count="2">
@@ -73,7 +76,7 @@ module Xlsxtream
           </cellStyleXfs>
           <cellXfs count="4">
             <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
-            <xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+            <xf numFmtId="164" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
             <xf numFmtId="165" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
             <xf numFmtId="0" fontId="1" fillId="2" borderId="0" xfId="0" applyFont="1" applyFill="1"/>
           </cellXfs>

--- a/spec/models/dossier_preloader_spec.rb
+++ b/spec/models/dossier_preloader_spec.rb
@@ -48,7 +48,7 @@ describe DossierPreloader do
     end
   end
 
-  describe 'in_batches_with_block' do
+  describe '#in_batches (preloading for PDF/zip export)' do
     let(:instructeur) { create(:instructeur) }
     let(:expert) { create(:expert) }
     let(:experts_procedure) { create(:experts_procedure, expert:, procedure:) }
@@ -74,7 +74,7 @@ describe DossierPreloader do
       all_dossiers = Dossier.where(id: dossiers.map(&:id))
       loaded_dossiers = []
 
-      DossierPreloader.new(all_dossiers).in_batches_with_block do |batch|
+      DossierPreloader.new(all_dossiers).in_batches(includes: DossierPreloader::PJ_EXPORT_INCLUDES) do |batch|
         loaded_dossiers = batch
       end
 
@@ -100,6 +100,69 @@ describe DossierPreloader do
       end
 
       expect(count).to eq(0)
+    end
+  end
+
+  describe '#in_batches (streamed, ordered for sheet export)' do
+    let(:instructeur) { create(:instructeur) }
+    let(:procedure) { create(:procedure, :published, :for_individual, instructeurs: [instructeur]) }
+
+    let!(:dossiers) do
+      [3.days.ago, 1.day.ago, 2.days.ago].map do |depose_at|
+        dossier = create(:dossier, :en_instruction, :with_individual, procedure:)
+        dossier.update_column(:depose_at, depose_at)
+        create(:groupe_instructeur, label: 'gi', procedure:) if dossier == nil # noop, just to ensure procedure has gi
+        dossier
+      end
+    end
+
+    let(:dossier_includes) do
+      [
+        :user,
+        :individual,
+        :followers_instructeurs,
+        :traitement,
+        :groupe_instructeur,
+        :etablissement,
+        :pending_corrections,
+        { procedure: [:groupe_instructeurs] },
+        { avis: [:claimant, :expert] },
+      ]
+    end
+
+    it 'yields dossiers in depose_at order across batches without materializing all dossiers' do
+      all_dossiers = procedure.dossiers
+      yielded = []
+
+      DossierPreloader.new(all_dossiers.ordered_for_export).in_batches(includes: dossier_includes) do |batch|
+        yielded.concat(batch)
+      end
+
+      expect(yielded.map(&:id)).to eq(all_dossiers.ordered_for_export.pluck(:id))
+    end
+
+    it 'preloads requested includes (no N+1 inside the block)' do
+      all_dossiers = procedure.dossiers
+
+      DossierPreloader.new(all_dossiers.ordered_for_export).in_batches(includes: dossier_includes) do |batch|
+        count = 0
+        callback = lambda { |*_args| count += 1 }
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          batch.each do |dossier|
+            dossier.user&.email
+            dossier.individual&.gender
+            dossier.traitement&.processed_at
+            dossier.groupe_instructeur&.label
+            dossier.etablissement&.siret
+            dossier.procedure.groupe_instructeurs.to_a
+            dossier.followers_instructeurs.to_a
+            dossier.avis.each { |a| a.claimant&.email; a.expert&.email }
+            dossier.pending_corrections.to_a
+            dossier.champs.to_a # champs préchargés via load_dossiers
+          end
+        end
+        expect(count).to eq(0)
+      end
     end
   end
 end

--- a/spec/perf/export_spec.rb
+++ b/spec/perf/export_spec.rb
@@ -54,7 +54,7 @@ describe 'Export performance' do
       query_count = 0
 
       ActiveSupport::Notifications.subscribed(lambda { |*_args| query_count += 1 }, "sql.active_record") do
-        DossierPreloader.new(all_dossiers).in_batches_with_block do |loaded|
+        DossierPreloader.new(all_dossiers).in_batches(includes: DossierPreloader::PJ_EXPORT_INCLUDES) do |loaded|
           pj_service.generate_dossiers_export(loaded)
         end
       end

--- a/spec/services/procedure_export_service/xlsx_streamer_spec.rb
+++ b/spec/services/procedure_export_service/xlsx_streamer_spec.rb
@@ -128,9 +128,16 @@ describe ProcedureExportService::XlsxStreamer do
       expect(sheet_xml).to match(/<c r="B1" s="3"/)
     end
 
-    it 'declares the datetime format with unescaped code so Numbers recognizes it' do
+    it 'declares the datetime format with unescaped code so readers recognize it as a date' do
       styles = read_zip_entry('xl/styles.xml')
       expect(styles).to include('formatCode="yyyy-mm-dd h:mm AM/PM"')
+    end
+
+    # caxlsx (previous export) styled Date columns with the custom code
+    # "yyyy-mm-dd", not the locale-dependent built-in numFmtId 14.
+    it 'declares the date format with a yyyy-mm-dd code matching the caxlsx export' do
+      styles = read_zip_entry('xl/styles.xml')
+      expect(styles).to include('formatCode="yyyy-mm-dd"')
     end
 
     it 'sets column widths' do

--- a/spec/services/procedure_export_service/xlsx_streamer_spec.rb
+++ b/spec/services/procedure_export_service/xlsx_streamer_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+describe ProcedureExportService::XlsxStreamer do
+  let(:io) { Tempfile.new(['xlsx_streamer_spec', '.xlsx'], binmode: true) }
+
+  after { io.close!; io.unlink rescue nil }
+
+  def read_sheets
+    io.rewind
+    xlsx = SimpleXlsxReader.open(io.path)
+    xlsx.sheets.each { |s| s.rows.slurp }
+    xlsx
+  end
+
+  describe 'with a single sheet' do
+    subject(:streamer) { described_class.new(io) }
+
+    it 'writes headers and a row of values' do
+      streamer.open do |writer|
+        writer.write_sheet('Test', headers: ['A', 'B', 'C']) do |sheet|
+          sheet.add_row(['hello', 42, nil])
+        end
+      end
+
+      sheet = read_sheets.sheets.first
+      expect(sheet.name).to eq('Test')
+      expect(sheet.headers).to eq(['A', 'B', 'C'])
+      expect(sheet.data).to eq([['hello', 42, nil]])
+    end
+
+    it 'coerces nil to empty string, symbol to string' do
+      streamer.open do |writer|
+        writer.write_sheet('S', headers: ['x']) do |sheet|
+          sheet.add_row([nil])
+          sheet.add_row([:foo])
+        end
+      end
+
+      sheet = read_sheets.sheets.first
+      expect(sheet.data).to eq([[nil], ['foo']])
+    end
+  end
+
+  describe 'formula-like values' do
+    subject(:streamer) { described_class.new(io) }
+
+    it 'writes them verbatim as inert text (xlsx string cells are never evaluated)' do
+      streamer.open do |writer|
+        writer.write_sheet('S', headers: ['x']) do |sheet|
+          sheet.add_row(['=1+1'])
+          sheet.add_row(['+formula'])
+          sheet.add_row(['-cmd'])
+          sheet.add_row(['@dde'])
+          sheet.add_row(["\tfoo"])
+          sheet.add_row(["\rbar"])
+          sheet.add_row(['safe'])
+        end
+      end
+
+      sheet = read_sheets.sheets.first
+      values = sheet.data.flatten
+      # No leading "'" escape (unlike CSV): the values are stored as-is, matching
+      # the previous caxlsx export. Note: XML normalizes \r to \n on serialization
+      # (XML 1.0 spec), so SimpleXlsxReader gives back "\nbar" for the \r case.
+      expect(values).to eq(['=1+1', '+formula', '-cmd', '@dde', "\tfoo", "\nbar", 'safe'])
+    end
+  end
+
+  describe 'with multiple sheets' do
+    subject(:streamer) { described_class.new(io) }
+
+    it 'writes them sequentially in order' do
+      streamer.open do |writer|
+        writer.write_sheet('First', headers: ['a']) { |s| s.add_row([1]) }
+        writer.write_sheet('Second', headers: ['b']) { |s| s.add_row([2]) }
+      end
+
+      expect(read_sheets.sheets.map(&:name)).to eq(['First', 'Second'])
+    end
+  end
+
+  describe 'sheet name sanitization' do
+    subject(:streamer) { described_class.new(io) }
+
+    it 'replaces forbidden chars and truncates to 30 ASCII bytes' do
+      raw = 'Élève / Dossier *[] très long ' * 3
+      streamer.open do |writer|
+        writer.write_sheet(raw, headers: ['x']) { |s| s.add_row(['v']) }
+      end
+
+      name = read_sheets.sheets.first.name
+      expect(name.bytesize).to be <= 30
+      expect(name).not_to match(%r{[/\\*?\[\]]})
+      expect(name).to eq(I18n.transliterate(raw, locale: :en).delete('/\*?[]').truncate(30, omission: ''))
+    end
+  end
+
+  describe 'styling and value types' do
+    subject(:streamer) { described_class.new(io) }
+
+    def read_zip_entry(name)
+      io.rewind
+      Zip::File.open(io.path) { |zip| zip.read(name) }
+    end
+
+    before do
+      streamer.open do |writer|
+        writer.write_sheet('Test', headers: ['Header A', 'Bool']) do |sheet|
+          sheet.add_row(['text', true])
+          sheet.add_row(['text2', false])
+        end
+      end
+    end
+
+    it 'writes a Ruby boolean as a native boolean cell (t="b")' do
+      expect(read_sheets.sheets.first.data).to eq([['text', true], ['text2', false]])
+    end
+
+    it 'styles each header cell with a black fill and a white font' do
+      styles = read_zip_entry('xl/styles.xml')
+      expect(styles).to include('<fgColor rgb="FF000000"/>')
+      expect(styles).to include('rgb="FFFFFFFF"')
+
+      # Numbers honors cell-level styles, not row-level ones, so each header
+      # cell must carry the style index directly.
+      sheet_xml = read_zip_entry('xl/worksheets/sheet1.xml')
+      expect(sheet_xml).to match(/<c r="A1" s="3"/)
+      expect(sheet_xml).to match(/<c r="B1" s="3"/)
+    end
+
+    it 'declares the datetime format with unescaped code so Numbers recognizes it' do
+      styles = read_zip_entry('xl/styles.xml')
+      expect(styles).to include('formatCode="yyyy-mm-dd h:mm AM/PM"')
+    end
+
+    it 'sets column widths' do
+      sheet_xml = read_zip_entry('xl/worksheets/sheet1.xml')
+      expect(sheet_xml).to match(/<col [^>]*width="[^"]+"[^>]*customWidth="1"/)
+    end
+  end
+end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -142,6 +142,20 @@ describe ProcedureExportService do
         end
       end
 
+      context 'with an untyped boolean column (no export_template)' do
+        let(:procedure) { create(:procedure, :published, :for_individual) }
+        let!(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:) }
+
+        # Parité avec l'export caxlsx historique : un booléen *non typé* sort en
+        # texte (SpreadsheetArchitect#get_type → :string), pas en cellule native
+        # t="b". Les colonnes explicitement typées :boolean (export_template)
+        # restent natives, cf. spec tabular yes_no/checkbox.
+        it 'exports the boolean as the string "false", not a native boolean cell' do
+          value = dossiers_sheet.data[0][dossiers_sheet.headers.index('FranceConnect ?')]
+          expect(value).to eq('false')
+        end
+      end
+
       context 'with a procedure routee' do
         let(:procedure) { create(:procedure, :published, :for_individual) }
         let!(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:) }
@@ -168,7 +182,7 @@ describe ProcedureExportService do
       end
 
       context 'with procedure chorus' do
-        before { expect_any_instance_of(Procedure).to receive(:chorusable?).and_return(true) }
+        before { allow_any_instance_of(Procedure).to receive(:chorusable?).and_return(true) }
         let(:procedure) { create(:procedure, :published, :for_individual, :filled_chorus) }
         let!(:dossier) { create(:dossier, :en_instruction, procedure: procedure) }
 


### PR DESCRIPTION
## Contexte

Les gros exports Excel faisaient grimper la RAM du worker Sidekiq `exports` (jusqu'à +10 GB sur certains exports), car tout le classeur — et donc tous les champs — était construit en mémoire avant écriture (spreadsheet_architect / caxlsx).

## Ce que fait cette PR

Branche la génération **xlsx** sur un flux en mémoire bornée : on ne détient jamais plus d'un batch de dossiers à la fois.

- `DossierPreloader#in_batches(includes:)` : méthode unique de batch (remplace l'ancienne `in_batches` qui matérialisait tout, et `in_batches_with_block`). Plucke les IDs, recharge par tranches avec les `includes` en conservant l'ordre de la relation (l'appelant choisit l'ordre, ex. `ordered_for_export`), et relâche chaque batch au fil de l'eau.
- `XlsxStreamer` (au-dessus de `xlsxtream`) : écrit le classeur ligne à ligne, en-têtes stylés.
- `XlsxExport` : orchestre la passe Dossiers en streaming, puis écrit les feuilles secondaires (Établissements, Avis, Répétitions).

## Parité de format (pas de breaking change pour les instructeurs)

Cette PR ne change **que** la mémoire, **pas le rendu** : structure, en-têtes, colonnes et valeurs sont identiques à la sortie caxlsx/spreadsheet_architect actuelle. Deux points méritent d'être explicités, car `xlsxtream` ne se comporte pas comme caxlsx par défaut et on l'aligne volontairement :

- **Booléens : on reproduit exactement le typage de SpreadsheetArchitect.** Une colonne **explicitement typée `:boolean`** (chemin export_template, ex. yes_no / checkbox) sort en **cellule native** `t="b"` ; un booléen **non typé** (ex. « FranceConnect ? », « Établissement siège social », « Réponse oui/non », chemin sans export_template) sort en **texte** `"true"`/`"false"`. C'est le comportement de `caxlsx` depuis ~2016. Sinon, `xlsxtream` écrirait *tout* en booléen natif et le rendu `VRAI/FAUX` pourrait casser des intégrations.
- **Formats de date et datetime forcés** dans `lib/core_ext/xlsxtream.rb` : `yyyy-mm-dd` pour les dates, `yyyy-mm-dd h:mm AM/PM` pour les datetimes. `xlsxtream` impose par défaut ses propres codes de format (échappés) ; on rétablit les mêmes codes que caxlsx pour que les colonnes restent reconnues comme des dates par les lecteurs (Excel, LibreOffice, Numbers…) et s'affichent à l'identique.

## Périmètre

xlsx uniquement. `to_csv` et `to_ods` restent inchangés (caxlsx/rodf en RAM) pour cette PR ; on verra comment adapter les autres plus tard, mais ils représentent moins de 10 % des exports, et plutôt des petits exports.

## Pistes écartées

- **Fusionner N petits fichiers** (générés par batch) en un gros : pas de lib robuste de fusion xlsx/ods en mémoire bornée → chirurgie XML fragile.
- **Convertisseur Rust hors-process** (spill JSONL par batch + binaire `rust_xlsxwriter` en mémoire constante) : il faut écrire le code côté Rails pour produire les données *et* le code Rust pour les convertir — d'autant que les sorties xlsx et csv ne sont déjà pas exactement les mêmes (colonnes Établissement inline en CSV, feuilles séparées en xlsx). S'ajoute un binaire à embarquer dans l'infra. Trop de complexité au regard du besoin.
- **`fast_excel`** (binding FFI vers libxlsxwriter) : écarté à cause d'instabilités remontées et d'un amont peu maintenu.
- **Convertisseur pur-Ruby depuis des spills** (même archi, sink Ruby) : finalement *plus* de code que xlsxtream (writers par format), à rebours de l'objectif « moins de code, moins complexe ».

`xlsxtream` reste donc le meilleur compromis robustesse / maintenabilité / mémoire en pur Ruby.

## Suite possible (ce que ne fait pas cette PR)

- CSV streamé via la stdlib `CSV` + `in_batches` (borne le format le plus volumineux, ~20 LOC).
- ODS streamé à la main (content.xml séquentiel, pas de table de chaînes partagées). Usage marginal.
- Streamer réellement les établissements, avis et répétitions (aujourd'hui bufferisés en mémoire le temps d'écrire la feuille Dossiers, puisque `xlsxtream` ne sait pas entrelacer les feuilles).
- Améliorer les formats au-delà de la parité (booléens natifs, dates en cellules natives partout), en assumant les breaking changes côté intégrations.
